### PR TITLE
Add extension traits

### DIFF
--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -11,6 +11,22 @@
 //! assert_eq!(hyperlink_style, anstyle::RgbColor(0x00, 0x00, 0xee) | anstyle::Effects::UNDERLINE);
 //! ```
 
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+trait Ext: sealed::Sealed + Sized {
+    fn parse(s: &str) -> Result<Self, Error>;
+}
+
+impl sealed::Sealed for anstyle::Style {}
+
+impl Ext for anstyle::Style {
+    fn parse(s: &str) -> Result<Self, Error> {
+        parse(s)
+    }
+}
+
 /// Parse a string in Git's color configuration syntax into an
 /// `ansi_term::Style`.
 pub fn parse(s: &str) -> Result<anstyle::Style, Error> {
@@ -255,5 +271,11 @@ mod tests {
         test!("#bcdefg" => UnknownWord "#bcdefg");
         test!("#blue" => UnknownWord "#blue");
         test!("blue#123456" => UnknownWord "blue#123456");
+    }
+
+    #[test]
+    fn test_extension_trait() {
+        let style = anstyle::Style::parse("red blue");
+        assert_eq!(style.unwrap(), Red | Blue);
     }
 }

--- a/crates/owo/src/lib.rs
+++ b/crates/owo/src/lib.rs
@@ -1,3 +1,19 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+trait Ext: sealed::Sealed {
+    fn to_owo(self) -> owo_colors::Style;
+}
+
+impl sealed::Sealed for anstyle::Style {}
+
+impl Ext for anstyle::Style {
+    fn to_owo(self) -> owo_colors::Style {
+        to_owo_style(self)
+    }
+}
+
 pub fn to_owo_style(style: anstyle::Style) -> owo_colors::Style {
     let fg = style.get_fg_color().map(to_owo_colors);
     let bg = style.get_bg_color().map(to_owo_colors);

--- a/crates/termcolor/src/lib.rs
+++ b/crates/termcolor/src/lib.rs
@@ -1,3 +1,19 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+trait Ext: sealed::Sealed {
+    fn to_termcolor(self) -> termcolor::ColorSpec;
+}
+
+impl sealed::Sealed for anstyle::Style {}
+
+impl Ext for anstyle::Style {
+    fn to_termcolor(self) -> termcolor::ColorSpec {
+        to_termcolor_spec(self)
+    }
+}
+
 pub fn to_termcolor_spec(style: anstyle::Style) -> termcolor::ColorSpec {
     let fg = style.get_fg_color().map(to_termcolor_color);
     let bg = style.get_bg_color().map(to_termcolor_color);

--- a/crates/yansi/src/lib.rs
+++ b/crates/yansi/src/lib.rs
@@ -1,3 +1,19 @@
+mod sealed {
+    pub(crate) trait Sealed {}
+}
+
+trait Ext: sealed::Sealed {
+    fn to_yansi(self) -> yansi::Style;
+}
+
+impl sealed::Sealed for anstyle::Style {}
+
+impl Ext for anstyle::Style {
+    fn to_yansi(self) -> yansi::Style {
+        to_yansi_style(self)
+    }
+}
+
 pub fn to_yansi_style(style: anstyle::Style) -> yansi::Style {
     let fg = style
         .get_fg_color()


### PR DESCRIPTION
- anstyle-git: Add extension trait to provide method on `anstyle::Style`
- anstyle-owo: Add extension trait to provide `to_owo` method on `anstyle::Style`
- anstyle-termcolor: Add extension trait to provide `to_termcolor` method on `anstyle::Style`
- anstyle-yansi: Add extension trait to provide `to_yansi` method on `anstyle::Style`
