### PR TITLE
docs(git): Add "colorparse" keyword to help people find anstyle-git

### DIFF
--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/rust-cli/anstyle"
 documentation = "http://docs.rs/anstyle-git/"
 readme = "README.md"
 categories = ["command-line-interface"]
-keywords = ["ansi", "terminal", "color", "git"]
+keywords = ["ansi", "terminal", "color", "git", "colorparse"]
 include = [
   "build.rs",
   "src/**/*",


### PR DESCRIPTION
colorparse is deprecated in favor of anstyle-git.
