### PR TITLE
feat(anstyle): Support additional underline styles 

### DIFF
--- a/crates/anstyle/examples/dump.rs
+++ b/crates/anstyle/examples/dump.rs
@@ -67,11 +67,15 @@ impl Args {
                     })?;
                 }
                 Long("effect") => {
-                    const EFFECTS: [(&str, anstyle::Effects); 8] = [
+                    const EFFECTS: [(&str, anstyle::Effects); 12] = [
                         ("bold", anstyle::Effects::BOLD),
                         ("dimmed", anstyle::Effects::DIMMED),
                         ("italic", anstyle::Effects::ITALIC),
                         ("underline", anstyle::Effects::UNDERLINE),
+                        ("double_underline", anstyle::Effects::UNDERLINE),
+                        ("curly_underline", anstyle::Effects::CURLY_UNDERLINE),
+                        ("dotted_underline", anstyle::Effects::DOTTED_UNDERLINE),
+                        ("dashed_underline", anstyle::Effects::DASHED_UNDERLINE),
                         ("blink", anstyle::Effects::BLINK),
                         ("invert", anstyle::Effects::INVERT),
                         ("hidden", anstyle::Effects::HIDDEN),

--- a/crates/anstyle/src/color.rs
+++ b/crates/anstyle/src/color.rs
@@ -77,9 +77,9 @@ impl From<(u8, u8, u8)> for Color {
 /// # Examples
 ///
 /// ```rust
-/// let black = anstyle::Color::from((0, 0, 0));
-/// let white = anstyle::Color::from((0xff, 0xff, 0xff));
-/// let style = black | white;
+/// let fg = anstyle::Color::from((0, 0, 0));
+/// let bg = anstyle::Color::from((0xff, 0xff, 0xff));
+/// let style = fg | bg;
 /// ```
 impl<C: Into<Color>> core::ops::BitOr<C> for Color {
     type Output = crate::Style;
@@ -97,8 +97,8 @@ impl<C: Into<Color>> core::ops::BitOr<C> for Color {
 /// # Examples
 ///
 /// ```rust
-/// let color = anstyle::Color::from((0, 0, 0));
-/// let style = color | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
+/// let fg = anstyle::Color::from((0, 0, 0));
+/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
 /// ```
 impl core::ops::BitOr<crate::Effects> for Color {
     type Output = crate::Style;
@@ -239,9 +239,9 @@ impl AnsiColorFmt for AnsiColor {
 /// # Examples
 ///
 /// ```rust
-/// let black = anstyle::AnsiColor::Black;
-/// let white = anstyle::AnsiColor::White;
-/// let style = black | white;
+/// let fg = anstyle::AnsiColor::Black;
+/// let bg = anstyle::AnsiColor::White;
+/// let style = fg | bg;
 /// ```
 impl<C: Into<Color>> core::ops::BitOr<C> for AnsiColor {
     type Output = crate::Style;
@@ -259,8 +259,8 @@ impl<C: Into<Color>> core::ops::BitOr<C> for AnsiColor {
 /// # Examples
 ///
 /// ```rust
-/// let color = anstyle::AnsiColor::Black;
-/// let style = color | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
+/// let fg = anstyle::AnsiColor::Black;
+/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
 /// ```
 impl core::ops::BitOr<crate::Effects> for AnsiColor {
     type Output = crate::Style;
@@ -375,9 +375,9 @@ impl From<AnsiColor> for XTermColor {
 /// # Examples
 ///
 /// ```rust
-/// let black = anstyle::XTermColor(16);
-/// let white = anstyle::XTermColor(231);
-/// let style = black | white;
+/// let fg = anstyle::XTermColor(16);
+/// let bg = anstyle::XTermColor(231);
+/// let style = fg | bg;
 /// ```
 impl<C: Into<Color>> core::ops::BitOr<C> for XTermColor {
     type Output = crate::Style;
@@ -395,8 +395,8 @@ impl<C: Into<Color>> core::ops::BitOr<C> for XTermColor {
 /// # Examples
 ///
 /// ```rust
-/// let color = anstyle::XTermColor(0);
-/// let style = color | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
+/// let fg = anstyle::XTermColor(0);
+/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
 /// ```
 impl core::ops::BitOr<crate::Effects> for XTermColor {
     type Output = crate::Style;
@@ -470,9 +470,9 @@ impl From<(u8, u8, u8)> for RgbColor {
 /// # Examples
 ///
 /// ```rust
-/// let black = anstyle::RgbColor(0, 0, 0);
-/// let white = anstyle::RgbColor(0xff, 0xff, 0xff);
-/// let style = black | white;
+/// let fg = anstyle::RgbColor(0, 0, 0);
+/// let bg = anstyle::RgbColor(0xff, 0xff, 0xff);
+/// let style = fg | bg;
 /// ```
 impl<C: Into<Color>> core::ops::BitOr<C> for RgbColor {
     type Output = crate::Style;
@@ -490,8 +490,8 @@ impl<C: Into<Color>> core::ops::BitOr<C> for RgbColor {
 /// # Examples
 ///
 /// ```rust
-/// let color = anstyle::RgbColor(0, 0, 0);
-/// let style = color | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
+/// let fg = anstyle::RgbColor(0, 0, 0);
+/// let style = fg | anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
 /// ```
 impl core::ops::BitOr<crate::Effects> for RgbColor {
     type Output = crate::Style;

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -6,7 +6,7 @@
 /// let effects = anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE;
 /// ```
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Effects(u8);
+pub struct Effects(u16);
 
 impl Effects {
     const PLAIN: Self = Effects(0);
@@ -17,12 +17,16 @@ impl Effects {
     pub const ITALIC: Self = Effects(1 << 2);
     /// Style extensions exist for Kitty, VTE, mintty and iTerm2.
     pub const UNDERLINE: Self = Effects(1 << 3);
-    pub const BLINK: Self = Effects(1 << 4);
+    pub const DOUBLE_UNDERLINE: Self = Effects(1 << 4);
+    pub const CURLY_UNDERLINE: Self = Effects(1 << 5);
+    pub const DOTTED_UNDERLINE: Self = Effects(1 << 6);
+    pub const DASHED_UNDERLINE: Self = Effects(1 << 7);
+    pub const BLINK: Self = Effects(1 << 8);
     /// Swap foreground and background colors; inconsistent emulation
-    pub const INVERT: Self = Effects(1 << 5);
-    pub const HIDDEN: Self = Effects(1 << 6);
+    pub const INVERT: Self = Effects(1 << 9);
+    pub const HIDDEN: Self = Effects(1 << 10);
     ///  Characters legible but marked as if for deletion. Not supported in Terminal.app
-    pub const STRIKETHROUGH: Self = Effects(1 << 7);
+    pub const STRIKETHROUGH: Self = Effects(1 << 11);
 
     /// No effects enabled
     ///
@@ -235,41 +239,70 @@ impl core::ops::SubAssign for Effects {
 
 pub(crate) struct Metadata {
     pub(crate) name: &'static str,
-    pub(crate) code: usize,
+    pub(crate) primary: usize,
+    pub(crate) secondary: Option<usize>,
 }
 
-pub(crate) const METADATA: [Metadata; 8] = [
+pub(crate) const METADATA: [Metadata; 12] = [
     Metadata {
         name: "BOLD",
-        code: 1,
+        primary: 1,
+        secondary: None,
     },
     Metadata {
         name: "DIMMED",
-        code: 2,
+        primary: 2,
+        secondary: None,
     },
     Metadata {
         name: "ITALIC",
-        code: 3,
+        primary: 3,
+        secondary: None,
     },
     Metadata {
         name: "UNDERLINE",
-        code: 4,
+        primary: 4,
+        secondary: None,
+    },
+    Metadata {
+        name: "DOUBLE_UNDERLINE",
+        primary: 4,
+        secondary: Some(2),
+    },
+    Metadata {
+        name: "CURLY_UNDERLINE",
+        primary: 4,
+        secondary: Some(3),
+    },
+    Metadata {
+        name: "DOTTED_UNDERLINE",
+        primary: 4,
+        secondary: Some(4),
+    },
+    Metadata {
+        name: "DASHED_UNDERLINE",
+        primary: 4,
+        secondary: Some(5),
     },
     Metadata {
         name: "BLINK",
-        code: 5,
+        primary: 5,
+        secondary: None,
     },
     Metadata {
         name: "INVERT",
-        code: 7,
+        primary: 7,
+        secondary: None,
     },
     Metadata {
         name: "HIDDEN",
-        code: 8,
+        primary: 8,
+        secondary: None,
     },
     Metadata {
         name: "STRIKETHROUGH",
-        code: 9,
+        primary: 9,
+        secondary: None,
     },
 ];
 
@@ -286,7 +319,10 @@ impl core::fmt::Display for EffectsDisplay {
             if i != 0 {
                 write!(f, ";")?;
             }
-            write!(f, "{}", METADATA[index].code)?;
+            write!(f, "{}", METADATA[index].primary)?;
+            if let Some(secondary) = METADATA[index].secondary {
+                write!(f, ":{}", secondary)?;
+            }
         }
         write!(f, "m")?;
         Ok(())

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -15,7 +15,7 @@ impl Effects {
     pub const DIMMED: Self = Effects(1 << 1);
     /// Not widely supported. Sometimes treated as inverse or blink
     pub const ITALIC: Self = Effects(1 << 2);
-    /// Style extensions exist for Kitty, VTE, mintty and iTerm2.[
+    /// Style extensions exist for Kitty, VTE, mintty and iTerm2.
     pub const UNDERLINE: Self = Effects(1 << 3);
     pub const BLINK: Self = Effects(1 << 4);
     /// Swap foreground and background colors; inconsistent emulation

--- a/crates/anstyle/src/style.rs
+++ b/crates/anstyle/src/style.rs
@@ -374,7 +374,10 @@ impl core::fmt::Display for StyleDisplay {
 
         for index in self.0.effects.index_iter() {
             separator(f, &mut first)?;
-            write!(f, "{}", crate::effect::METADATA[index].code)?;
+            write!(f, "{}", crate::effect::METADATA[index].primary)?;
+            if let Some(secondary) = crate::effect::METADATA[index].secondary {
+                write!(f, ":{}", secondary)?;
+            }
         }
 
         if let Some(fg) = self.0.fg {


### PR DESCRIPTION
Rather than breaking this out into its own enum, I decided to just treat
them as independent effects.

Fixes #28