### PR TITLE
feat(parse): Let Perform control print vs execute 

### DIFF
--- a/crates/anstyle-parse/benches/parse.rs
+++ b/crates/anstyle-parse/benches/parse.rs
@@ -42,7 +42,7 @@ impl Strip {
 }
 impl Perform for Strip {
     fn print_control(byte: u8) -> bool {
-        byte == b'\n'
+        byte.is_ascii_whitespace()
     }
     fn print(&mut self, c: char) {
         self.0.push(c);

--- a/crates/anstyle-parse/benches/parse.rs
+++ b/crates/anstyle-parse/benches/parse.rs
@@ -41,14 +41,11 @@ impl Strip {
     }
 }
 impl Perform for Strip {
+    fn print_control(byte: u8) -> bool {
+        byte == b'\n'
+    }
     fn print(&mut self, c: char) {
         self.0.push(c);
-    }
-
-    fn execute(&mut self, byte: u8) {
-        if byte == b'\n' {
-            self.0.push(byte as char);
-        }
     }
 }
 

--- a/crates/anstyle-parse/src/lib.rs
+++ b/crates/anstyle-parse/src/lib.rs
@@ -199,6 +199,7 @@ where
     fn perform_action<P: Perform>(&mut self, performer: &mut P, action: Action, byte: u8) {
         match action {
             Action::Print => performer.print(byte as char),
+            Action::Execute if P::print_control(byte) => performer.print(byte as char),
             Action::Execute => performer.execute(byte),
             Action::Hook => {
                 if self.params.is_full() {
@@ -392,6 +393,12 @@ impl<'a> utf8::Receiver for VtUtf8Receiver<'a> {
 /// referenced if something isn't clear. If the site disappears at some point in
 /// the future, consider checking archive.org.
 pub trait Perform {
+    /// Whether single-byte control characters should be [`Perform::execute`]d or
+    /// [`Perform::print`]ed.
+    fn print_control(_byte: u8) -> bool {
+        false
+    }
+
     /// Draw a character to the screen and update states.
     fn print(&mut self, _c: char) {}
 


### PR DESCRIPTION
This makes it so users can just specify `print`, not much of a win.

The big win will be when we add batch printing support as this will
allow fewer interruptions.