### PR TITLE
feat(parse): Parser::advance_str for bulk operations

### DIFF
--- a/crates/anstyle-parse/benches/parse.rs
+++ b/crates/anstyle-parse/benches/parse.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, Criterion};
 use anstyle_parse::*;
 
 struct BenchDispatcher;
-impl Perform for BenchDispatcher {
+impl Perform<char> for BenchDispatcher {
     fn print(&mut self, c: char) {
         black_box(c);
     }
@@ -40,7 +40,7 @@ impl Strip {
         Self(String::with_capacity(capacity))
     }
 }
-impl Perform for Strip {
+impl Perform<char> for Strip {
     fn print_control(byte: u8) -> bool {
         byte.is_ascii_whitespace()
     }

--- a/crates/anstyle-parse/benches/parse.rs
+++ b/crates/anstyle-parse/benches/parse.rs
@@ -98,13 +98,13 @@ fn parse(c: &mut Criterion) {
         ),
     ] {
         let mut group = c.benchmark_group(name);
-        group.bench_function("advance", |b| {
+        group.bench_function("advance_byte", |b| {
             b.iter(|| {
                 let mut dispatcher = BenchDispatcher;
                 let mut parser = Parser::<DefaultCharAccumulator>::new();
 
                 for byte in content {
-                    parser.advance(&mut dispatcher, *byte);
+                    parser.advance_byte(&mut dispatcher, *byte);
                 }
             })
         });
@@ -118,20 +118,20 @@ fn parse(c: &mut Criterion) {
                 })
             });
         }
-        group.bench_function("advance_strip", |b| {
+        group.bench_function("advance_byte(strip)", |b| {
             b.iter(|| {
                 let mut stripped = Strip::with_capacity(content.len());
                 let mut parser = Parser::<DefaultCharAccumulator>::new();
 
                 for byte in content {
-                    parser.advance(&mut stripped, *byte);
+                    parser.advance_byte(&mut stripped, *byte);
                 }
 
                 black_box(stripped.0)
             })
         });
         if let Ok(content) = std::str::from_utf8(content) {
-            group.bench_function("advance_str_strip", |b| {
+            group.bench_function("advance_str(strip)", |b| {
                 b.iter(|| {
                     let mut stripped = Strip::with_capacity(content.len());
                     let mut parser = Parser::<DefaultCharAccumulator>::new();

--- a/crates/anstyle-parse/benches/parse.rs
+++ b/crates/anstyle-parse/benches/parse.rs
@@ -32,6 +32,35 @@ impl Perform<char> for BenchDispatcher {
         black_box((intermediates, ignore, byte));
     }
 }
+impl Perform<&'_ str> for BenchDispatcher {
+    fn print(&mut self, c: &'_ str) {
+        black_box(c);
+    }
+
+    fn execute(&mut self, byte: u8) {
+        black_box(byte);
+    }
+
+    fn hook(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: u8) {
+        black_box((params, intermediates, ignore, c));
+    }
+
+    fn put(&mut self, byte: u8) {
+        black_box(byte);
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
+        black_box((params, bell_terminated));
+    }
+
+    fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: u8) {
+        black_box((params, intermediates, ignore, c));
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+        black_box((intermediates, ignore, byte));
+    }
+}
 
 #[derive(Default)]
 struct Strip(String);
@@ -46,6 +75,14 @@ impl Perform<char> for Strip {
     }
     fn print(&mut self, c: char) {
         self.0.push(c);
+    }
+}
+impl Perform<&'_ str> for Strip {
+    fn print_control(byte: u8) -> bool {
+        byte.is_ascii_whitespace()
+    }
+    fn print(&mut self, c: &'_ str) {
+        self.0.push_str(c);
     }
 }
 
@@ -71,6 +108,16 @@ fn parse(c: &mut Criterion) {
                 }
             })
         });
+        if let Ok(content) = std::str::from_utf8(content) {
+            group.bench_function("advance_str", |b| {
+                b.iter(|| {
+                    let mut dispatcher = BenchDispatcher;
+                    let mut parser = Parser::<DefaultCharAccumulator>::new();
+
+                    parser.advance_str(&mut dispatcher, content);
+                })
+            });
+        }
         group.bench_function("advance_strip", |b| {
             b.iter(|| {
                 let mut stripped = Strip::with_capacity(content.len());
@@ -83,6 +130,18 @@ fn parse(c: &mut Criterion) {
                 black_box(stripped.0)
             })
         });
+        if let Ok(content) = std::str::from_utf8(content) {
+            group.bench_function("advance_str_strip", |b| {
+                b.iter(|| {
+                    let mut stripped = Strip::with_capacity(content.len());
+                    let mut parser = Parser::<DefaultCharAccumulator>::new();
+
+                    parser.advance_str(&mut stripped, content);
+
+                    black_box(stripped.0)
+                })
+            });
+        }
     }
 }
 

--- a/crates/anstyle-parse/examples/parselog.rs
+++ b/crates/anstyle-parse/examples/parselog.rs
@@ -6,7 +6,7 @@ use anstyle_parse::{DefaultCharAccumulator, Params, Parser, Perform};
 /// A type implementing Perform that just logs actions
 struct Log;
 
-impl Perform for Log {
+impl Perform<char> for Log {
     fn print(&mut self, c: char) {
         println!("[print] {:?}", c);
     }

--- a/crates/anstyle-parse/examples/parselog.rs
+++ b/crates/anstyle-parse/examples/parselog.rs
@@ -66,7 +66,7 @@ fn main() {
             Ok(0) => break,
             Ok(n) => {
                 for byte in &buf[..n] {
-                    statemachine.advance(&mut performer, *byte);
+                    statemachine.advance_byte(&mut performer, *byte);
                 }
             }
             Err(err) => {

--- a/crates/anstyle-parse/src/lib.rs
+++ b/crates/anstyle-parse/src/lib.rs
@@ -96,7 +96,10 @@ where
     ///
     /// Requires a [`Perform`] in case `byte` triggers an action
     #[inline]
-    pub fn advance<P: Perform>(&mut self, performer: &mut P, byte: u8) {
+    pub fn advance<P>(&mut self, performer: &mut P, byte: u8)
+    where
+        P: Perform<char>,
+    {
         // Utf8 characters are handled out-of-band.
         if let State::Utf8 = self.state {
             self.process_utf8(performer, byte);
@@ -120,7 +123,7 @@ where
     #[inline]
     fn process_utf8<P>(&mut self, performer: &mut P, byte: u8)
     where
-        P: Perform,
+        P: Perform<char>,
     {
         if let Some(c) = self.utf8_parser.add(byte) {
             performer.print(c);
@@ -131,7 +134,7 @@ where
     #[inline]
     fn perform_state_change<P>(&mut self, performer: &mut P, state: State, action: Action, byte: u8)
     where
-        P: Perform,
+        P: Perform<char>,
     {
         match state {
             State::Anywhere => {
@@ -179,7 +182,10 @@ where
     ///
     /// The aliasing is needed here for multiple slices into self.osc_raw
     #[inline]
-    fn osc_dispatch<P: Perform>(&self, performer: &mut P, byte: u8) {
+    fn osc_dispatch<P>(&self, performer: &mut P, byte: u8)
+    where
+        P: Perform<char>,
+    {
         let mut slices: [MaybeUninit<&[u8]>; MAX_OSC_PARAMS] =
             unsafe { MaybeUninit::uninit().assume_init() };
 
@@ -196,7 +202,10 @@ where
     }
 
     #[inline]
-    fn perform_action<P: Perform>(&mut self, performer: &mut P, action: Action, byte: u8) {
+    fn perform_action<P>(&mut self, performer: &mut P, action: Action, byte: u8)
+    where
+        P: Perform<char>,
+    {
         match action {
             Action::Print => performer.print(byte as char),
             Action::Execute if P::print_control(byte) => performer.print(byte as char),
@@ -392,7 +401,7 @@ impl<'a> utf8::Receiver for VtUtf8Receiver<'a> {
 /// a useful way in my own words for completeness, but the site should be
 /// referenced if something isn't clear. If the site disappears at some point in
 /// the future, consider checking archive.org.
-pub trait Perform {
+pub trait Perform<P> {
     /// Whether single-byte control characters should be [`Perform::execute`]d or
     /// [`Perform::print`]ed.
     fn print_control(_byte: u8) -> bool {
@@ -400,7 +409,7 @@ pub trait Perform {
     }
 
     /// Draw a character to the screen and update states.
-    fn print(&mut self, _c: char) {}
+    fn print(&mut self, _c: P) {}
 
     /// Execute a C0 or C1 control function.
     fn execute(&mut self, _byte: u8) {}

--- a/crates/anstyle-parse/src/lib.rs
+++ b/crates/anstyle-parse/src/lib.rs
@@ -141,7 +141,7 @@ where
         P: Perform<O>,
     {
         if let Some((byte, next)) = bytes.split_first() {
-            self.advance(&mut Forward::new(performer), *byte);
+            self.advance_byte(&mut Forward::new(performer), *byte);
             *bytes = next;
             true
         } else {
@@ -155,7 +155,7 @@ where
     ///
     /// [`Perform`]: trait.Perform.html
     #[inline]
-    pub fn advance<P>(&mut self, performer: &mut P, byte: u8)
+    pub fn advance_byte<P>(&mut self, performer: &mut P, byte: u8)
     where
         P: Perform<char>,
     {

--- a/crates/anstyle-parse/tests/testsuite.proptest-regressions
+++ b/crates/anstyle-parse/tests/testsuite.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 001bdfa800d266450c8dc1f7d2b63920b433ced8528f12f343c7925d1ab943c9 # shrinks to input = "𐂀"

--- a/crates/anstyle-parse/tests/testsuite.rs
+++ b/crates/anstyle-parse/tests/testsuite.rs
@@ -24,7 +24,7 @@ struct Dispatcher {
     dispatched: Vec<Sequence>,
 }
 
-impl Perform for Dispatcher {
+impl Perform<char> for Dispatcher {
     fn print(&mut self, c: char) {
         self.dispatched.push(Sequence::Print(c));
     }

--- a/crates/anstyle-parse/tests/testsuite.rs
+++ b/crates/anstyle-parse/tests/testsuite.rs
@@ -176,7 +176,7 @@ impl From<char> for Sequence {
     }
 }
 
-macro_rules! advance {
+macro_rules! advance_byte {
     ($name: ident, $gen: ident) => {
         #[test]
         fn $name() {
@@ -185,7 +185,7 @@ macro_rules! advance {
             let mut parser = Parser::<DefaultCharAccumulator>::new();
 
             for byte in &input {
-                parser.advance(&mut dispatcher, *byte);
+                parser.advance_byte(&mut dispatcher, *byte);
             }
 
             assert_eq!(expected, dispatcher);
@@ -222,7 +222,7 @@ fn gen_osc() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_osc, gen_osc);
+advance_byte!(advance_byte_osc, gen_osc);
 advance_str!(advance_str_osc, gen_osc);
 
 fn gen_empty_osc() -> (Vec<u8>, Dispatcher) {
@@ -231,7 +231,7 @@ fn gen_empty_osc() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_empty_osc, gen_empty_osc);
+advance_byte!(advance_byte_empty_osc, gen_empty_osc);
 advance_str!(advance_str_empty_osc, gen_empty_osc);
 
 fn gen_osc_max_params() -> (Vec<u8>, Dispatcher) {
@@ -241,7 +241,7 @@ fn gen_osc_max_params() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_osc_max_params, gen_osc_max_params);
+advance_byte!(advance_byte_osc_max_params, gen_osc_max_params);
 advance_str!(advance_str_osc_max_params, gen_osc_max_params);
 
 fn gen_osc_bell_terminated() -> (Vec<u8>, Dispatcher) {
@@ -254,7 +254,7 @@ fn gen_osc_bell_terminated() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_osc_bell_terminated, gen_osc_bell_terminated);
+advance_byte!(advance_byte_osc_bell_terminated, gen_osc_bell_terminated);
 advance_str!(advance_str_osc_bell_terminated, gen_osc_bell_terminated);
 
 fn gen_osc_c0_st_terminated() -> (Vec<u8>, Dispatcher) {
@@ -268,7 +268,7 @@ fn gen_osc_c0_st_terminated() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_osc_c0_st_terminated, gen_osc_c0_st_terminated);
+advance_byte!(advance_byte_osc_c0_st_terminated, gen_osc_c0_st_terminated);
 advance_str!(advance_str_osc_c0_st_terminated, gen_osc_c0_st_terminated);
 
 fn gen_osc_with_utf8_arguments() -> (Vec<u8>, Dispatcher) {
@@ -283,7 +283,10 @@ fn gen_osc_with_utf8_arguments() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_osc_with_utf8_arguments, gen_osc_with_utf8_arguments);
+advance_byte!(
+    advance_byte_osc_with_utf8_arguments,
+    gen_osc_with_utf8_arguments
+);
 advance_str!(
     advance_str_osc_with_utf8_arguments,
     gen_osc_with_utf8_arguments
@@ -300,8 +303,8 @@ fn gen_osc_containing_string_terminator() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_osc_containing_string_terminator,
+advance_byte!(
+    advance_byte_osc_containing_string_terminator,
     gen_osc_containing_string_terminator
 );
 
@@ -321,7 +324,10 @@ fn gen_exceed_max_buffer_size() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_exceed_max_buffer_size, gen_exceed_max_buffer_size);
+advance_byte!(
+    advance_byte_exceed_max_buffer_size,
+    gen_exceed_max_buffer_size
+);
 advance_str!(
     advance_str_exceed_max_buffer_size,
     gen_exceed_max_buffer_size
@@ -339,7 +345,7 @@ fn gen_csi_max_params() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_csi_max_params, gen_csi_max_params);
+advance_byte!(advance_byte_csi_max_params, gen_csi_max_params);
 advance_str!(advance_str_csi_max_params, gen_csi_max_params);
 
 fn gen_csi_params_ignore_long_params() -> (Vec<u8>, Dispatcher) {
@@ -353,8 +359,8 @@ fn gen_csi_params_ignore_long_params() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_csi_params_ignore_long_params,
+advance_byte!(
+    advance_byte_csi_params_ignore_long_params,
     gen_csi_params_ignore_long_params
 );
 
@@ -364,8 +370,8 @@ fn gen_csi_params_trailing_semicolon() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_csi_params_trailing_semicolon,
+advance_byte!(
+    advance_byte_csi_params_trailing_semicolon,
     gen_csi_params_trailing_semicolon
 );
 
@@ -375,8 +381,8 @@ fn gen_csi_params_leading_semicolon() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_csi_params_leading_semicolon,
+advance_byte!(
+    advance_byte_csi_params_leading_semicolon,
     gen_csi_params_leading_semicolon
 );
 
@@ -387,7 +393,7 @@ fn gen_csi_long_param() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_csi_long_param, gen_csi_long_param);
+advance_byte!(advance_byte_csi_long_param, gen_csi_long_param);
 advance_str!(advance_str_csi_long_param, gen_csi_long_param);
 
 fn gen_csi_reset() -> (Vec<u8>, Dispatcher) {
@@ -396,7 +402,7 @@ fn gen_csi_reset() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_csi_reset, gen_csi_reset);
+advance_byte!(advance_byte_csi_reset, gen_csi_reset);
 advance_str!(advance_str_csi_reset, gen_csi_reset);
 
 fn gen_csi_subparameters() -> (Vec<u8>, Dispatcher) {
@@ -406,7 +412,7 @@ fn gen_csi_subparameters() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_csi_subparameters, gen_csi_subparameters);
+advance_byte!(advance_byte_csi_subparameters, gen_csi_subparameters);
 advance_str!(advance_str_csi_subparameters, gen_csi_subparameters);
 
 fn gen_dcs_max_params() -> (Vec<u8>, Dispatcher) {
@@ -416,7 +422,7 @@ fn gen_dcs_max_params() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_dcs_max_params, gen_dcs_max_params);
+advance_byte!(advance_byte_dcs_max_params, gen_dcs_max_params);
 advance_str!(advance_str_dcs_max_params, gen_dcs_max_params);
 
 fn gen_dcs_reset() -> (Vec<u8>, Dispatcher) {
@@ -428,7 +434,7 @@ fn gen_dcs_reset() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_dcs_reset, gen_dcs_reset);
+advance_byte!(advance_byte_dcs_reset, gen_dcs_reset);
 // advance_str!(advance_str_dcs_reset, gen_dcs_reset);  // input isn't UTF-8
 
 fn gen_dcs() -> (Vec<u8>, Dispatcher) {
@@ -444,7 +450,7 @@ fn gen_dcs() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_dcs, gen_dcs);
+advance_byte!(advance_byte_dcs, gen_dcs);
 // advance_str!(advance_str_dcs, gen_dcs); // input isn't UTF-8
 
 fn gen_intermediate_reset_on_dcs_exit() -> (Vec<u8>, Dispatcher) {
@@ -459,8 +465,8 @@ fn gen_intermediate_reset_on_dcs_exit() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_intermediate_reset_on_dcs_exit,
+advance_byte!(
+    advance_byte_intermediate_reset_on_dcs_exit,
     gen_intermediate_reset_on_dcs_exit
 );
 
@@ -470,7 +476,7 @@ fn gen_esc_reset() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(advance_esc_reset, gen_esc_reset);
+advance_byte!(advance_byte_esc_reset, gen_esc_reset);
 advance_str!(advance_str_esc_reset, gen_esc_reset);
 
 fn gen_params_buffer_filled_with_subparam() -> (Vec<u8>, Dispatcher) {
@@ -479,8 +485,8 @@ fn gen_params_buffer_filled_with_subparam() -> (Vec<u8>, Dispatcher) {
     (input, expected)
 }
 
-advance!(
-    advance_params_buffer_filled_with_subparam,
+advance_byte!(
+    advance_byte_params_buffer_filled_with_subparam,
     gen_params_buffer_filled_with_subparam
 );
 
@@ -488,14 +494,14 @@ proptest! {
     #[test]
     #[cfg(feature = "utf8")]
     #[cfg_attr(any(miri, not(feature = "utf8")), ignore)]
-    fn advance_utf8(input in "\\PC*") {
+    fn advance_byte_utf8(input in "\\PC*") {
         let expected = Dispatcher::from(input.as_str());
 
         let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::<Utf8Parser>::new();
 
         for byte in input.as_bytes() {
-            parser.advance(&mut dispatcher, *byte);
+            parser.advance_byte(&mut dispatcher, *byte);
         }
 
         assert_eq!(expected, dispatcher);

--- a/crates/anstyle-parse/tests/testsuite.rs
+++ b/crates/anstyle-parse/tests/testsuite.rs
@@ -63,6 +63,45 @@ impl Perform<char> for Dispatcher {
     }
 }
 
+impl Perform<&'_ str> for Dispatcher {
+    fn print(&mut self, c: &'_ str) {
+        self.dispatched.extend(Dispatcher::from(c).dispatched);
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
+        let params = params.iter().map(|p| p.to_vec()).collect();
+        self.dispatched.push(Sequence::Osc(params, bell_terminated));
+    }
+
+    fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: u8) {
+        let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+        let intermediates = intermediates.to_vec();
+        self.dispatched
+            .push(Sequence::Csi(params, intermediates, ignore, c));
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+        let intermediates = intermediates.to_vec();
+        self.dispatched
+            .push(Sequence::Esc(intermediates, ignore, byte));
+    }
+
+    fn hook(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: u8) {
+        let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+        let intermediates = intermediates.to_vec();
+        self.dispatched
+            .push(Sequence::DcsHook(params, intermediates, ignore, c));
+    }
+
+    fn put(&mut self, byte: u8) {
+        self.dispatched.push(Sequence::DcsPut(byte));
+    }
+
+    fn unhook(&mut self) {
+        self.dispatched.push(Sequence::DcsUnhook);
+    }
+}
+
 impl std::ops::Deref for Dispatcher {
     type Target = [Sequence];
 
@@ -154,6 +193,22 @@ macro_rules! advance {
     };
 }
 
+macro_rules! advance_str {
+    ($name: ident, $gen: ident) => {
+        #[test]
+        fn $name() {
+            let (input, expected) = $gen();
+            let input = String::from_utf8(input).unwrap();
+            let mut dispatcher = Dispatcher::default();
+            let mut parser = Parser::<DefaultCharAccumulator>::new();
+
+            parser.advance_str(&mut dispatcher, &input);
+
+            assert_eq!(expected, dispatcher);
+        }
+    };
+}
+
 fn gen_osc() -> (Vec<u8>, Dispatcher) {
     let input = OSC_BYTES.to_vec();
     let expected = start()
@@ -168,6 +223,7 @@ fn gen_osc() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_osc, gen_osc);
+advance_str!(advance_str_osc, gen_osc);
 
 fn gen_empty_osc() -> (Vec<u8>, Dispatcher) {
     let input = [0x1b, 0x5d, 0x07].into();
@@ -176,6 +232,7 @@ fn gen_empty_osc() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_empty_osc, gen_empty_osc);
+advance_str!(advance_str_empty_osc, gen_empty_osc);
 
 fn gen_osc_max_params() -> (Vec<u8>, Dispatcher) {
     let params = ";".repeat(MAX_PARAMS + 1);
@@ -185,6 +242,7 @@ fn gen_osc_max_params() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_osc_max_params, gen_osc_max_params);
+advance_str!(advance_str_osc_max_params, gen_osc_max_params);
 
 fn gen_osc_bell_terminated() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b]11;ff/00/ff\x07".to_vec();
@@ -197,6 +255,7 @@ fn gen_osc_bell_terminated() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_osc_bell_terminated, gen_osc_bell_terminated);
+advance_str!(advance_str_osc_bell_terminated, gen_osc_bell_terminated);
 
 fn gen_osc_c0_st_terminated() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b]11;ff/00/ff\x1b\\".to_vec();
@@ -210,6 +269,7 @@ fn gen_osc_c0_st_terminated() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_osc_c0_st_terminated, gen_osc_c0_st_terminated);
+advance_str!(advance_str_osc_c0_st_terminated, gen_osc_c0_st_terminated);
 
 fn gen_osc_with_utf8_arguments() -> (Vec<u8>, Dispatcher) {
     let input = [
@@ -224,6 +284,10 @@ fn gen_osc_with_utf8_arguments() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_osc_with_utf8_arguments, gen_osc_with_utf8_arguments);
+advance_str!(
+    advance_str_osc_with_utf8_arguments,
+    gen_osc_with_utf8_arguments
+);
 
 fn gen_osc_containing_string_terminator() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b]2;\xe6\x9c\xab\x1b\\".to_vec();
@@ -258,6 +322,10 @@ fn gen_exceed_max_buffer_size() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_exceed_max_buffer_size, gen_exceed_max_buffer_size);
+advance_str!(
+    advance_str_exceed_max_buffer_size,
+    gen_exceed_max_buffer_size
+);
 
 fn gen_csi_max_params() -> (Vec<u8>, Dispatcher) {
     // This will build a list of repeating '1;'s
@@ -272,6 +340,7 @@ fn gen_csi_max_params() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_csi_max_params, gen_csi_max_params);
+advance_str!(advance_str_csi_max_params, gen_csi_max_params);
 
 fn gen_csi_params_ignore_long_params() -> (Vec<u8>, Dispatcher) {
     // This will build a list of repeating '1;'s
@@ -319,6 +388,7 @@ fn gen_csi_long_param() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_csi_long_param, gen_csi_long_param);
+advance_str!(advance_str_csi_long_param, gen_csi_long_param);
 
 fn gen_csi_reset() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b[3;1\x1b[?1049h".to_vec();
@@ -327,6 +397,7 @@ fn gen_csi_reset() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_csi_reset, gen_csi_reset);
+advance_str!(advance_str_csi_reset, gen_csi_reset);
 
 fn gen_csi_subparameters() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b[38:2:255:0:255;1m".to_vec();
@@ -336,6 +407,7 @@ fn gen_csi_subparameters() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_csi_subparameters, gen_csi_subparameters);
+advance_str!(advance_str_csi_subparameters, gen_csi_subparameters);
 
 fn gen_dcs_max_params() -> (Vec<u8>, Dispatcher) {
     let params = "1;".repeat(MAX_PARAMS + 1);
@@ -345,6 +417,7 @@ fn gen_dcs_max_params() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_dcs_max_params, gen_dcs_max_params);
+advance_str!(advance_str_dcs_max_params, gen_dcs_max_params);
 
 fn gen_dcs_reset() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b[3;1\x1bP1$tx\x9c".to_vec();
@@ -356,6 +429,7 @@ fn gen_dcs_reset() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_dcs_reset, gen_dcs_reset);
+// advance_str!(advance_str_dcs_reset, gen_dcs_reset);  // input isn't UTF-8
 
 fn gen_dcs() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1bP0;1|17/ab\x9c".to_vec();
@@ -371,6 +445,7 @@ fn gen_dcs() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_dcs, gen_dcs);
+// advance_str!(advance_str_dcs, gen_dcs); // input isn't UTF-8
 
 fn gen_intermediate_reset_on_dcs_exit() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1bP=1sZZZ\x1b+\x5c".to_vec();
@@ -396,6 +471,7 @@ fn gen_esc_reset() -> (Vec<u8>, Dispatcher) {
 }
 
 advance!(advance_esc_reset, gen_esc_reset);
+advance_str!(advance_str_esc_reset, gen_esc_reset);
 
 fn gen_params_buffer_filled_with_subparam() -> (Vec<u8>, Dispatcher) {
     let input = b"\x1b[::::::::::::::::::::::::::::::::x\x1b".to_vec();
@@ -421,6 +497,20 @@ proptest! {
         for byte in input.as_bytes() {
             parser.advance(&mut dispatcher, *byte);
         }
+
+        assert_eq!(expected, dispatcher);
+    }
+
+    #[test]
+    #[cfg(feature = "utf8")]
+    #[cfg_attr(any(miri, not(feature = "utf8")), ignore)]
+    fn advance_str_utf8(input in "\\PC*") {
+        let expected = Dispatcher::from(input.as_str());
+
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::<Utf8Parser>::new();
+
+        parser.advance_str(&mut dispatcher, &input);
 
         assert_eq!(expected, dispatcher);
     }


### PR DESCRIPTION
`advance_str` is much easier to implement than `advance_bytes` as it
doesn't have to deal with a UTF-8 state machine mixed in with the slice
gathering.

Performance

tl;dr faster than all but the most dense of escape code cases
```
rg_help.vte/advance_byte
                        time:   [19.407 µs 19.470 µs 19.540 µs]
rg_help.vte/advance_str
                        time:   [6.9290 µs 6.9606 µs 6.9933 µs]

rg_help.vte/advance_byte(strip)
                        time:   [25.557 µs 25.681 µs 25.817 µs]
rg_help.vte/advance_str(strip)
                        time:   [6.4233 µs 6.4521 µs 6.4817 µs]


rg_linus.vte/advance_byte
                        time:   [434.35 µs 436.07 µs 437.83 µs]
rg_linus.vte/advance_str
                        time:   [379.78 µs 381.75 µs 383.95 µs]

rg_linus.vte/advance_byte(strip)
                        time:   [471.51 µs 474.86 µs 480.77 µs]
rg_linus.vte/advance_str(strip)
                        time:   [374.54 µs 375.69 µs 376.88 µs]


state_changes/advance_byte
                        time:   [74.463 ns 74.699 ns 74.943 ns]
state_changes/advance_str
                        time:   [102.82 ns 103.39 ns 103.97 ns]

state_changes/advance_byte(strip)
                        time:   [81.074 ns 81.423 ns 81.793 ns]
state_changes/advance_str(strip)
                        time:   [115.91 ns 116.58 ns 117.28 ns]
```