### PR TITLE
fix(anstyle): Adjust underline behavior

### DIFF
--- a/crates/anstyle/examples/dump.rs
+++ b/crates/anstyle/examples/dump.rs
@@ -102,7 +102,7 @@ impl Args {
                         ("dimmed", anstyle::Effects::DIMMED),
                         ("italic", anstyle::Effects::ITALIC),
                         ("underline", anstyle::Effects::UNDERLINE),
-                        ("double_underline", anstyle::Effects::UNDERLINE),
+                        ("double_underline", anstyle::Effects::DOUBLE_UNDERLINE),
                         ("curly_underline", anstyle::Effects::CURLY_UNDERLINE),
                         ("dotted_underline", anstyle::Effects::DOTTED_UNDERLINE),
                         ("dashed_underline", anstyle::Effects::DASHED_UNDERLINE),

--- a/crates/anstyle/src/effect.rs
+++ b/crates/anstyle/src/effect.rs
@@ -266,8 +266,8 @@ pub(crate) const METADATA: [Metadata; 12] = [
     },
     Metadata {
         name: "DOUBLE_UNDERLINE",
-        primary: 4,
-        secondary: Some(2),
+        primary: 21,
+        secondary: None,
     },
     Metadata {
         name: "CURLY_UNDERLINE",


### PR DESCRIPTION
This is after testing in wezterm.

Notes:
- westerm encourages `:` over `;` but we want `;` for max compatibility
- Underline colors are not working
- `4:n` underline styles are not working