### PR TITLE
feat(wincon): Allow locking the Console

### DIFF
--- a/crates/anstyle-wincon/examples/dump.rs
+++ b/crates/anstyle-wincon/examples/dump.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(not(windows), allow(dead_code))]
-
-#[cfg(not(windows))]
-fn main() {
-    panic!("unsupported");
-}
-
-#[cfg(windows)]
 fn main() -> Result<(), lexopt::Error> {
     let args = Args::parse()?;
     let stdout = std::io::stdout();
@@ -52,7 +44,6 @@ fn style(fixed: u8, layer: Layer, effects: anstyle::Effects) -> anstyle::Style {
     }) | effects
 }
 
-#[cfg(windows)]
 fn print_number(
     stdout: &mut anstyle_wincon::Console<std::io::StdoutLock<'_>>,
     fixed: u8,

--- a/crates/anstyle-wincon/src/console.rs
+++ b/crates/anstyle-wincon/src/console.rs
@@ -3,7 +3,7 @@ pub struct Console<S>
 where
     S: crate::WinconStream + std::io::Write,
 {
-    stream: S,
+    stream: Option<S>,
     initial_fg: anstyle::AnsiColor,
     initial_bg: anstyle::AnsiColor,
     last_fg: anstyle::AnsiColor,
@@ -21,7 +21,7 @@ where
     fn from_stream(stream: S) -> std::io::Result<Self> {
         let (initial_fg, initial_bg) = stream.get_colors()?;
         Ok(Self {
-            stream,
+            stream: Some(stream),
             initial_fg,
             initial_bg,
             last_fg: initial_fg,
@@ -37,7 +37,7 @@ where
         data: &[u8],
     ) -> std::io::Result<usize> {
         self.apply(fg.unwrap_or(self.initial_fg), bg.unwrap_or(self.initial_bg))?;
-        let written = self.stream.write(data)?;
+        let written = self.as_stream_mut().write(data)?;
         Ok(written)
     }
 
@@ -57,13 +57,54 @@ where
         }
 
         // Ensure everything is written with the last set of colors before applying the next set
-        self.stream.flush()?;
+        self.as_stream_mut().flush()?;
 
-        self.stream.set_colors(fg, bg)?;
+        self.as_stream_mut().set_colors(fg, bg)?;
         self.last_fg = fg;
         self.last_bg = bg;
 
         Ok(())
+    }
+
+    fn as_stream_mut(&mut self) -> &mut S {
+        self.stream.as_mut().unwrap()
+    }
+}
+
+impl<S> Console<S>
+where
+    S: crate::WinconStream + std::io::Write,
+    S: crate::Lockable,
+    <S as crate::Lockable>::Locked: crate::WinconStream + std::io::Write,
+{
+    /// Get exclusive access to the `Console`
+    ///
+    /// Why?
+    /// - Faster performance when writing in a loop
+    /// - Avoid other threads interleaving output with the current thread
+    #[inline]
+    pub fn lock(mut self) -> <Self as crate::Lockable>::Locked {
+        Console {
+            stream: Some(self.stream.take().unwrap().lock()),
+            initial_fg: self.initial_fg,
+            initial_bg: self.initial_bg,
+            last_fg: self.last_fg,
+            last_bg: self.last_bg,
+        }
+    }
+}
+
+impl<S> crate::Lockable for Console<S>
+where
+    S: crate::WinconStream + std::io::Write,
+    S: crate::Lockable,
+    <S as crate::Lockable>::Locked: crate::WinconStream + std::io::Write,
+{
+    type Locked = Console<<S as crate::Lockable>::Locked>;
+
+    #[inline]
+    fn lock(self) -> Self::Locked {
+        self.lock()
     }
 }
 
@@ -72,6 +113,9 @@ where
     S: crate::WinconStream + std::io::Write,
 {
     fn drop(&mut self) {
-        let _ = self.reset();
+        // Otherwise `Console::lock` took it
+        if self.stream.is_some() {
+            let _ = self.reset();
+        }
     }
 }

--- a/crates/anstyle-wincon/src/console.rs
+++ b/crates/anstyle-wincon/src/console.rs
@@ -4,10 +4,10 @@ where
     S: crate::WinconStream + std::io::Write,
 {
     stream: Option<S>,
-    initial_fg: anstyle::AnsiColor,
-    initial_bg: anstyle::AnsiColor,
-    last_fg: anstyle::AnsiColor,
-    last_bg: anstyle::AnsiColor,
+    initial_fg: Option<anstyle::AnsiColor>,
+    initial_bg: Option<anstyle::AnsiColor>,
+    last_fg: Option<anstyle::AnsiColor>,
+    last_bg: Option<anstyle::AnsiColor>,
 }
 
 impl<S> Console<S>
@@ -36,7 +36,7 @@ where
         bg: Option<anstyle::AnsiColor>,
         data: &[u8],
     ) -> std::io::Result<usize> {
-        self.apply(fg.unwrap_or(self.initial_fg), bg.unwrap_or(self.initial_bg))?;
+        self.apply(fg, bg)?;
         let written = self.as_stream_mut().write(data)?;
         Ok(written)
     }
@@ -51,7 +51,13 @@ where
         self.reset()
     }
 
-    fn apply(&mut self, fg: anstyle::AnsiColor, bg: anstyle::AnsiColor) -> std::io::Result<()> {
+    fn apply(
+        &mut self,
+        fg: Option<anstyle::AnsiColor>,
+        bg: Option<anstyle::AnsiColor>,
+    ) -> std::io::Result<()> {
+        let fg = fg.or(self.initial_fg);
+        let bg = bg.or(self.initial_bg);
         if fg == self.last_fg && bg == self.last_bg {
             return Ok(());
         }

--- a/crates/anstyle-wincon/src/lib.rs
+++ b/crates/anstyle-wincon/src/lib.rs
@@ -11,9 +11,11 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod console;
+mod lockable;
 mod stream;
 #[cfg(windows)]
 mod windows;
 
 pub use console::Console;
+pub use lockable::Lockable;
 pub use stream::WinconStream;

--- a/crates/anstyle-wincon/src/lockable.rs
+++ b/crates/anstyle-wincon/src/lockable.rs
@@ -1,0 +1,31 @@
+/// Explicitly lock a [`std::io::Write`]able
+pub trait Lockable {
+    type Locked;
+
+    /// Get exclusive access to the `Stream`
+    ///
+    /// Why?
+    /// - Faster performance when writing in a loop
+    /// - Avoid other threads interleaving output with the current thread
+    fn lock(self) -> Self::Locked;
+}
+
+impl Lockable for std::io::Stdout {
+    type Locked = std::io::StdoutLock<'static>;
+
+    #[inline]
+    fn lock(self) -> Self::Locked {
+        #[allow(clippy::needless_borrow)] // Its needed to avoid recursion
+        (&self).lock()
+    }
+}
+
+impl Lockable for std::io::Stderr {
+    type Locked = std::io::StderrLock<'static>;
+
+    #[inline]
+    fn lock(self) -> Self::Locked {
+        #[allow(clippy::needless_borrow)] // Its needed to avoid recursion
+        (&self).lock()
+    }
+}


### PR DESCRIPTION
This moves the `Console` so the original, with its stale state, doesn't
get used.

To make this easier to test, I also added support for non-Windows