### PR TITLE
feat(stream): Support env-based auto-detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
  "anstyle-parse",
  "anstyle-wincon",
  "concolor-override",
- "concolor-query 0.2.0",
+ "concolor-query 0.3.0",
  "criterion",
  "is-terminal",
  "owo-colors",
@@ -313,9 +313,9 @@ checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
 
 [[package]]
 name = "concolor-query"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cd70b9f86dd588a4a08471ebbd5847cb25f0116aaddeace95470cce096ff7d"
+checksum = "534eb40da54945b820debad8620cdcf0b2be6f174f139d34f373a29ab688a1d3"
 dependencies = [
  "windows-sys 0.45.0",
 ]

--- a/crates/anstyle-stream/Cargo.toml
+++ b/crates/anstyle-stream/Cargo.toml
@@ -34,7 +34,7 @@ anstyle = { version = "0.3.0", path = "../anstyle" }
 anstyle-parse = { version = "0.1.0", path = "../anstyle-parse" }
 anstyle-wincon = { version = "0.1.0", path = "../anstyle-wincon", optional = true }
 concolor-override = { version = "1.0.0", optional = true }
-concolor-query = { version = "0.2.0", optional = true }
+concolor-query = { version = "0.3.0", optional = true }
 is-terminal = { version = "0.4.4", optional = true }
 utf8parse = "0.2.1"
 

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -30,10 +30,13 @@ where
     pub fn new(raw: S, choice: ColorChoice) -> Self {
         match choice {
             ColorChoice::Auto => {
+                let clicolor = concolor_query::clicolor();
+                let clicolor_enabled = clicolor.unwrap_or(false);
+                let clicolor_disabled = !clicolor.unwrap_or(true);
                 if raw.is_terminal()
                     && !concolor_query::no_color()
-                    && concolor_query::term_supports_color()
-                    && concolor_query::clicolor()
+                    && !clicolor_disabled
+                    && (concolor_query::term_supports_color() || clicolor_enabled)
                     || concolor_query::clicolor_force()
                 {
                     Self::always(raw)

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -33,6 +33,7 @@ where
                 if raw.is_terminal()
                     && !concolor_query::no_color()
                     && concolor_query::term_supports_color()
+                    && concolor_query::clicolor()
                 {
                     Self::always(raw)
                 } else {

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -30,7 +30,7 @@ where
     pub fn new(raw: S, choice: ColorChoice) -> Self {
         match choice {
             ColorChoice::Auto => {
-                if raw.is_terminal() {
+                if raw.is_terminal() && !concolor_query::no_color() {
                     Self::always(raw)
                 } else {
                     Self::never(raw)

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -78,8 +78,9 @@ where
     pub fn always(raw: S) -> Self {
         if cfg!(windows) {
             #[cfg(feature = "auto")]
-            let use_wincon =
-                raw.is_terminal() && !concolor_query::windows::enable_ansi_colors().unwrap_or(true);
+            let use_wincon = raw.is_terminal()
+                && !concolor_query::windows::enable_ansi_colors().unwrap_or(true)
+                && !concolor_query::term_supports_ansi_color();
             #[cfg(not(feature = "auto"))]
             let use_wincon = true;
             if use_wincon {

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -76,21 +76,20 @@ where
     /// Force color, no matter what the inner `Write` supports.
     #[inline]
     pub fn always(raw: S) -> Self {
-        #[cfg(feature = "wincon")]
-        {
+        if cfg!(windows) {
             #[cfg(feature = "auto")]
             let use_wincon =
                 raw.is_terminal() && !concolor_query::windows::enable_ansi_colors().unwrap_or(true);
             #[cfg(not(feature = "auto"))]
-            let use_wincon = cfg!(windows);
+            let use_wincon = true;
             if use_wincon {
                 Self::wincon(raw).unwrap_or_else(|raw| Self::always_ansi_(raw))
             } else {
                 Self::always_ansi_(raw)
             }
+        } else {
+            Self::always_ansi(raw)
         }
-        #[cfg(not(feature = "wincon"))]
-        Self::always_ansi(raw)
     }
 
     /// Only pass printable data to the inner `Write`.
@@ -101,7 +100,6 @@ where
     }
 
     #[inline]
-    #[cfg(feature = "wincon")]
     fn wincon(raw: S) -> Result<Self, S> {
         #[cfg(feature = "wincon")]
         {

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -34,6 +34,7 @@ where
                     && !concolor_query::no_color()
                     && concolor_query::term_supports_color()
                     && concolor_query::clicolor()
+                    || concolor_query::clicolor_force()
                 {
                     Self::always(raw)
                 } else {

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -30,7 +30,10 @@ where
     pub fn new(raw: S, choice: ColorChoice) -> Self {
         match choice {
             ColorChoice::Auto => {
-                if raw.is_terminal() && !concolor_query::no_color() {
+                if raw.is_terminal()
+                    && !concolor_query::no_color()
+                    && concolor_query::term_supports_color()
+                {
                     Self::always(raw)
                 } else {
                     Self::never(raw)

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -78,7 +78,12 @@ where
     pub fn always(raw: S) -> Self {
         #[cfg(feature = "wincon")]
         {
-            if raw.is_terminal() && !concolor_query::windows::enable_ansi_colors().unwrap_or(true) {
+            #[cfg(feature = "auto")]
+            let use_wincon =
+                raw.is_terminal() && !concolor_query::windows::enable_ansi_colors().unwrap_or(true);
+            #[cfg(not(feature = "auto"))]
+            let use_wincon = cfg!(windows);
+            if use_wincon {
                 Self::wincon(raw).unwrap_or_else(|raw| Self::always_ansi_(raw))
             } else {
                 Self::always_ansi_(raw)


### PR DESCRIPTION
This supports
- [`NO_COLOR`](https://no-color.org/)
- [`CLICOLOR` / `CLICOLOR_FORCE`](https://bixense.com/clicolors/)
- `TERM` per [`termcolor`](https://github.com/BurntSushi/termcolor/blob/04966b49ff3516a724a6276c9b40b1716ff4f164/src/lib.rs#L255,L313)

I had originally wanted to leave this to the application but it is a pain to deal with
- `anstyle_stream::stdout` and `astyle_stream::print` become worthless
- We could let apps do it through the global but correctly avoiding wincon breaks this

`supports-color` takes [a different approach](https://github.com/zkat/supports-color/blob/f4fd9f4f62ea827d9be9620a5335db3dea5955b0/src/lib.rs#L91,L115):
- `COLORTERM`: since we aren't dealing with truecolor vs 256 vs 16, this mostly isn't needed
- We are more permissive in assuming 16 color support for `TERM`
- We don't auto-enable for CI
- We don't check `FORCE_COLOR`  which isn't really a documented standard in any way
  - This is derived from the node version which uses it to read the level of support (none, 16 color, 256 color, truecolor)
    - [ansis](https://github.com/webdiscus/ansis) compares different JS libs and whether they support it
  - rich supports checking the presence of it in Textualize/rich#2449 (which means it'll do the wrong thing on `0`)

Some things I disagree with `supports-color`
- `CLICOLOR_FORCE` disallows truecolor (which isn't as relevant for us)
- `CLICOLOR=0` does not disable color support despite the definition being "Don’t output ANSI color escape codes"

I wish there was a way for us to detect if we are being piped to `less -r`.