### PR TITLE
feat(stream): Auto-enabled color for CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
  "anstyle-parse",
  "anstyle-wincon",
  "concolor-override",
- "concolor-query 0.3.0",
+ "concolor-query 0.3.1",
  "criterion",
  "is-terminal",
  "owo-colors",
@@ -313,9 +313,9 @@ checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
 
 [[package]]
 name = "concolor-query"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534eb40da54945b820debad8620cdcf0b2be6f174f139d34f373a29ab688a1d3"
+checksum = "e26417f76e1387253c4d2bdac4de27c3f1ff9b78d1c0c07ce35f88bc7eb697fd"
 dependencies = [
  "windows-sys 0.45.0",
 ]

--- a/crates/anstyle-stream/Cargo.toml
+++ b/crates/anstyle-stream/Cargo.toml
@@ -34,7 +34,7 @@ anstyle = { version = "0.3.0", path = "../anstyle" }
 anstyle-parse = { version = "0.1.0", path = "../anstyle-parse" }
 anstyle-wincon = { version = "0.1.0", path = "../anstyle-wincon", optional = true }
 concolor-override = { version = "1.0.0", optional = true }
-concolor-query = { version = "0.3.0", optional = true }
+concolor-query = { version = "0.3.1", optional = true }
 is-terminal = { version = "0.4.4", optional = true }
 utf8parse = "0.2.1"
 

--- a/crates/anstyle-stream/src/auto.rs
+++ b/crates/anstyle-stream/src/auto.rs
@@ -36,7 +36,9 @@ where
                 if raw.is_terminal()
                     && !concolor_query::no_color()
                     && !clicolor_disabled
-                    && (concolor_query::term_supports_color() || clicolor_enabled)
+                    && (concolor_query::term_supports_color()
+                        || clicolor_enabled
+                        || concolor_query::is_ci())
                     || concolor_query::clicolor_force()
                 {
                     Self::always(raw)


### PR DESCRIPTION
This is a follow up to #72

CI is a common enough of a piped target that supports ANSI escape codes for us to treat it like `TERM` detection, I hope.  We'll see how feedback works out on this.