### PR TITLE
fix(anstyle): Add trailing newline to dump-style example output

### DIFF
--- a/crates/anstyle/examples/dump-style.rs
+++ b/crates/anstyle/examples/dump-style.rs
@@ -34,6 +34,8 @@ fn main() -> Result<(), lexopt::Error> {
         let _ = print_number(&mut stdout, fixed, style);
     }
 
+    let _ = writeln!(stdout);
+
     Ok(())
 }
 


### PR DESCRIPTION
dump-style lacked a trailing newline at the end of its output, leaving
the cursor on the same line as its last line, and causing the user's
prompt to end up on that same line. Add a trailing newline.
